### PR TITLE
fix undefined method empty for puppet4

### DIFF
--- a/templates/etc/rsyslog.d/papertrail.conf.erb
+++ b/templates/etc/rsyslog.d/papertrail.conf.erb
@@ -42,7 +42,7 @@ $ActionQueueTimeoutEnqueue <%= @action_queue_timeout_enqueue %>
 $ActionQueueDiscardSeverity <%= @action_queue_discard_severity %>
 <%- end -%>
 
-*.* @@<%= @host %><% unless @port.empty? %>:<%= @port %><% end %>
+*.* @@<%= @host %><% if @port %>:<%= @port %><% end %>
 
 <% unless @optional_files.empty? %>
 $ModLoad imfile


### PR DESCRIPTION
To fix the following error for puppet4 migration:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Failed to parse template papertrail/etc/rsyslog.d/papertrail.conf.erb:
  Filepath: /etc/puppetlabs/code/modules/papertrail/templates/etc/rsyslog.d/papertrail.conf.erb
  Line: 45
  Detail: undefined method `empty?' for 23047:Fixnum
 at /etc/puppetlabs/code/modules/papertrail/manifests/install.pp:32:16 on node web02.weholi.skyscrape.rs
```
